### PR TITLE
Fix broken configuration watching

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,9 @@
   ],
   "description": "Animated dial gauge for AngularJS",
   "main": "src/angular-dialgauge.js",
+  "dependencies": {
+    "angular": "^1.3.0"
+  },
   "keywords": [
     "AngularJS",
     "Javascript",

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,8 +3,8 @@
 <head>
     <title>Angular dialgauge demo</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular-sanitize.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.20/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.20/angular-sanitize.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
     <script src="../src/angular-dialgauge.js"></script>
 

--- a/src/angular-dialgauge.js
+++ b/src/angular-dialgauge.js
@@ -140,7 +140,7 @@ angular.module('angular-dialgauge', [
 
                 // Add a watch on all configuration variables.
                 // If anything changes, update the static path
-                $scope.$watch([
+                $scope.$watchGroup([
                     'rotate',
                     'angle',
                     'scaleMin',


### PR DESCRIPTION
$scope.$watch() only works on single expressions, not arrays.
Instead, use $scope.$watchGroup().  As this functionality was
introduced in Angular.js 1.3, also bump the minimum dependency and
the version used in the demo to that version.  This was found over
in https://github.com/nebulous/infinitude and was causing the dial
to display incorrectly when using an expression for scaleMax that
wasn't ready when the dial was first drawn.