### PR TITLE
Fix dial getting stuck on NaN sometimes during animation

### DIFF
--- a/src/angular-dialgauge.js
+++ b/src/angular-dialgauge.js
@@ -177,6 +177,13 @@ angular.module('angular-dialgauge', [
 
                 // Set a watch on the model so we can update the dynamic part of the gauge
                 $scope.$watch("ngModel", function (value) {
+                    // Sanitize the input to make sure no junk sneaks in
+                    // and gets the gauge stuck on NaN
+                    value = Number(value);
+                    if (isNaN(value)) {
+                        return;
+                    }
+
                     // The gauge isn't updated immediately.
                     // We use a timer to update the gauge dynamically
                     if (currentValue == null) {


### PR DESCRIPTION
Sometimes the ngModel values were being interpreted as strings
rather than numbers, causing the "intermediateValue += step"
computation to append strings instead of doing arithmetic.  This of
course resulted in NaN getting produced by the next computation,
which caused NaN to be shown on the dial.  To make matters worse,
since all computations involving NaN result in NaN, any future
attempt to update the dial would also produce NaN, resulting in
the dial being stuck on NaN.  To solve this problem, cast all
values from ngModel to Number and ignore any value that results in
NaN.